### PR TITLE
Handle NULL post slugs from the new app

### DIFF
--- a/models/posts.js
+++ b/models/posts.js
@@ -15,7 +15,8 @@ module.exports = function PostModel(sequelize, DataTypes) {
       allowNull: false,
     },
     status: { type: DataTypes.ENUM('draft', 'published', 'deleted'), allowNull: false, defaultValue: 'draft' },
-    slug: { type: DataTypes.STRING, allowNull: false, unique: true },
+    // Nullable since the new app creates drafts with slug NULL until publish
+    slug: { type: DataTypes.STRING, allowNull: true, unique: true },
     group_id: {
       type: DataTypes.INTEGER.UNSIGNED,
       references: {

--- a/routes/graphql/mutations/posts.js
+++ b/routes/graphql/mutations/posts.js
@@ -41,6 +41,10 @@ const postMutations = {
     post.content = cleanContent(args.content)
     post.status = args.status
     post.group_id = args.groupId
+    // Drafts from the new app have no slug until published
+    if (!post.slug && post.status === 'published') {
+      post.slug = await generateSlug(Post, post.title)
+    }
 
     await post.save()
     return post

--- a/routes/graphql/mutations/posts.js
+++ b/routes/graphql/mutations/posts.js
@@ -4,10 +4,17 @@ const { Post } = require('../../../models')
 const { cleanContent } = require('../../../utils/content')
 
 
+function timestampSlug(slug) {
+  // Keep room for the suffix — truncating after appending would return a
+  // 200-char base unchanged and keep the collision
+  const suffix = `-${Date.now()}`
+  return slug.substr(0, 200 - suffix.length) + suffix
+}
+
 async function generateSlug(Model, name) {
   const slug = slugify(name, { lower: true }).substr(0, 200)
   const slugExist = await Model.findOne({ where: { slug } })
-  if (slugExist) return `${slug}-${Date.now()}`.substr(0, 200)
+  if (slugExist) return timestampSlug(slug)
   return slug
 }
 
@@ -42,11 +49,18 @@ const postMutations = {
     post.status = args.status
     post.group_id = args.groupId
     // Drafts from the new app have no slug until published
-    if (!post.slug && post.status === 'published') {
-      post.slug = await generateSlug(Post, post.title)
-    }
+    const mintedSlug = !post.slug && post.status === 'published'
+    if (mintedSlug) post.slug = await generateSlug(Post, post.title)
 
-    await post.save()
+    try {
+      await post.save()
+    } catch (err) {
+      // slug is the only unique key — a concurrent publish won the
+      // check-then-save race, so retry once with a timestamped slug
+      if (!mintedSlug || err.name !== 'SequelizeUniqueConstraintError') throw err
+      post.slug = timestampSlug(post.slug)
+      await post.save()
+    }
     return post
   },
 

--- a/routes/graphql/typeDefs/types.graphql
+++ b/routes/graphql/typeDefs/types.graphql
@@ -64,7 +64,7 @@ type PostsList {
 type Post {
   id: ID!
   title: String!
-  slug: String!
+  slug: String
   status: PostStatus
   content: String
   htmlContent: String


### PR DESCRIPTION
The new app creates drafts with slug NULL until publish (posts.slug is being made nullable). Model allowNull, GraphQL Post.slug nullable, and editPost generates a slug when publishing a slug-less draft.

```sql
ALTER TABLE posts MODIFY `slug` varchar(255)
  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL, ALGORITHM=COPY;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Draft posts can now be saved without a slug.
  * A slug is automatically generated when a draft is published.

* **Bug Fixes**
  * Improved post publishing to ensure published posts receive a valid slug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->